### PR TITLE
UPLOAD ANDROID 11 (R) SOURCE OF 20A

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 VERSION = 4
 PATCHLEVEL = 14
-SUBLEVEL = 117
+SUBLEVEL = 169
 EXTRAVERSION =
 NAME = Petit Gorille
 


### PR DESCRIPTION
@realme-kernel-opensource Hey, RUi 2.0 Based on Android 11(R) was released long ago but didn't got the kernel source of it. So, Upload it As Soon As Possible. 